### PR TITLE
Fix PATH variable update suggestion in setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Refer the [Docker Usage](https://github.com/ucsb-seclab/dr_checker/blob/speedy/d
 ## 1. Setup
 Our implementation is based on LLVM, specifically LLVM 3.8. We also need tools like `c2xml` to parse headers.
 
-First, make sure that you have libxml (required for c2xml):
+First, make sure that you have cmake (used by setup/build scripts) and libxml (required for c2xml):
 ```
-sudo apt-get install libxml2-dev
+sudo apt-get install cmake libxml2-dev
 ```
 
 Next, We have created a single script, which downloads and builds all the required tools.

--- a/helper_scripts/setup_drchecker.py
+++ b/helper_scripts/setup_drchecker.py
@@ -109,8 +109,8 @@ def main():
     log_success("Build Complete.")
     print ""
     log_success("Add following lines to your .bashrc")
-    print("export LLVM_ROOT=", build_dir)
-    print("export PATH=$LLVM_ROOT/bin:" + sparse_dir + ":$PATH")
+    print("export LLVM_ROOT=" + os.path.abspath(build_dir))
+    print("export PATH=$LLVM_ROOT/bin:" + os.path.abspath(sparse_dir) + ":$PATH")
     print ""
     log_success("After adding the above lines to .bashrc.\nPlease run: source ~/.bashrc on the "
                 "terminal for the changes to take effect.")


### PR DESCRIPTION
Partial output when running `python setup_drchecker.py -o drchecker_deps` per `README.md`:

```
[100%] Built target c-index-test
[+]  Build Complete.

[+]  Add following lines to your .bashrc
('export LLVM_ROOT=', 'drchecker_deps/llvm/build')
export PATH=$LLVM_ROOT/bin:drchecker_deps/sparse:$PATH

[+]  After adding the above lines to .bashrc.
Please run: source ~/.bashrc on the terminal for the changes to take effect.

[+]  Setup Complete.
````
2 problems here:
- First `export` command print is formatted incorrectly
- Both `export` commands include relative paths (directory searched changes with the current working directory)

Using the relative paths caused the below error output when running `python run_all.py -l ~/mediatek_kernel/llvm_bitcode_out -a 1 -m ~/mediatek_kernel/kernel-3.18/makeout.txt -g aarch64-linux-android-gcc -n 2 -o ~/mediatek_kernel/kernel-3.18/out -k ~/mediatek_kernel/kernel-3.18 -f ~/mediatek_kernel/dr_checker_out` (couldn't find one of the sparse binaries):

```
Traceback (most recent call last):
File "run_all.py", line 167, in <module>
    main()
File "run_all.py", line 86, in main
    arg_dict['c2xml_bin'] = get_bin_path('c2xml')
File "run_all.py", line 56, in get_bin_path
    out_p = subprocess.check_output('which ' + bin_name, shell=True)
File "/usr/lib/python2.7/subprocess.py", line 574, in check_output
    raise CalledProcessError(retcode, cmd, output=output)
subprocess.CalledProcessError: Command 'which c2xml' returned non-zero exit status 1
```
Fixed by updating `setup_drchecker.py` to use absolute paths within these command prints. Also added mention of `cmake` to `README.md`, since it's needed by the setup and build scripts.