### PR TITLE
Fix gitignore wildcard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-**.pyc
+*.pyc
 **/.idea/
 llvm_analysis/MainAnalysisPasses/build_dir/
 llvm_analysis/AnalysisHelpers/Dr_linker/dr_linker


### PR DESCRIPTION
Leading `**/`, trailing `**/`, and `/**/` are the only valid uses of `**` in git globs.